### PR TITLE
Use new strat of MCA translation process 

### DIFF
--- a/Services/INbtService.cs
+++ b/Services/INbtService.cs
@@ -112,6 +112,23 @@ public interface INbtService
     /// <param name="filePath">File path</param>
     /// <returns>Whether it is a valid Anvil file</returns>
     Task<bool> IsValidAnvilFileAsync(string filePath);
+
+    // Chunk-based MCA processing methods
+    /// <summary>
+    ///     Convert MCA file to individual chunk SNBT files in a folder
+    /// </summary>
+    /// <param name="mcaFilePath">Input MCA file path</param>
+    /// <param name="outputFolderPath">Output folder path where chunk files will be saved</param>
+    /// <param name="progress">Progress reporter</param>
+    Task ConvertMcaToChunkFilesAsync(string mcaFilePath, string outputFolderPath, IProgress<string>? progress = null);
+
+    /// <summary>
+    ///     Convert folder of chunk SNBT files back to a single MCA file
+    /// </summary>
+    /// <param name="chunkFolderPath">Input folder containing chunk SNBT files</param>
+    /// <param name="outputMcaPath">Output MCA file path</param>
+    /// <param name="progress">Progress reporter</param>
+    Task ConvertChunkFilesToMcaAsync(string chunkFolderPath, string outputMcaPath, IProgress<string>? progress = null);
 }
 
 public class AnvilRegionInfo
@@ -143,6 +160,7 @@ public class AnvilChunkInfo
 
 public enum AnvilCompressionType
 {
+    None = 0,
     GZip = 1,
     Zlib = 2,
     Uncompressed = 3,

--- a/Services/NbtService.cs
+++ b/Services/NbtService.cs
@@ -1776,4 +1776,268 @@ public class NbtService : INbtService
             Console.WriteLine($@"Failed to parse chunk {chunkCoord.X},{chunkCoord.Z}: {ex.Message}");
         }
     }
+
+    // Chunk-based MCA processing methods
+    /// <summary>
+    ///     Convert MCA file to individual chunk SNBT files in a folder
+    /// </summary>
+    public async Task ConvertMcaToChunkFilesAsync(string mcaFilePath, string outputFolderPath, IProgress<string>? progress = null)
+    {
+        try
+        {
+            progress?.Report($"Loading MCA file: {Path.GetFileName(mcaFilePath)}...");
+
+            // Load the MCA file
+            using var mcaFile = new McaRegionFile(mcaFilePath);
+            await mcaFile.LoadAsync();
+
+            // Get existing chunks
+            List<Point2I> existingChunks = mcaFile.GetExistingChunks();
+
+            if (existingChunks.Count == 0)
+            {
+                progress?.Report("No chunks found in MCA file");
+                return;
+            }
+
+            progress?.Report($"Found {existingChunks.Count} chunks, creating individual files...");
+
+            // Create output directory if it doesn't exist
+            Directory.CreateDirectory(outputFolderPath);
+
+            // Create region info file
+            var regionInfo = new NbtCompound("RegionInfo");
+            regionInfo.Add(new NbtString("OriginalMcaPath", mcaFilePath));
+            regionInfo.Add(new NbtInt("RegionX", mcaFile.RegionCoordinates.X));
+            regionInfo.Add(new NbtInt("RegionZ", mcaFile.RegionCoordinates.Z));
+            regionInfo.Add(new NbtInt("TotalChunks", existingChunks.Count));
+            regionInfo.Add(new NbtString("ConversionTime", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")));
+            regionInfo.Add(new NbtString("ConversionType", "MCA to individual chunk files"));
+
+            string regionInfoPath = Path.Combine(outputFolderPath, "region_info.snbt");
+            string regionInfoSnbt = regionInfo.ToSnbt(SnbtOptions.DefaultExpanded);
+            await File.WriteAllTextAsync(regionInfoPath, regionInfoSnbt, Encoding.UTF8);
+
+            // Process each chunk
+            int processedCount = 0;
+            foreach (Point2I chunkCoord in existingChunks)
+            {
+                try
+                {
+                    if (processedCount % 10 == 0 || processedCount == existingChunks.Count - 1)
+                        progress?.Report($"Processing chunk {processedCount + 1}/{existingChunks.Count}: ({chunkCoord.X}, {chunkCoord.Z})");
+
+                    ChunkData? chunkData = await mcaFile.GetChunkAsync(chunkCoord);
+                    if (chunkData?.NbtData != null)
+                    {
+                        // Create filename with chunk coordinates: chunk_X_Z.snbt
+                        string chunkFileName = $"chunk_{chunkCoord.X}_{chunkCoord.Z}.snbt";
+                        string chunkFilePath = Path.Combine(outputFolderPath, chunkFileName);
+
+                        // Convert to SNBT with header comments
+                        var snbtContent = new StringBuilder();
+                        snbtContent.AppendLine($"// Chunk coordinates: ({chunkCoord.X}, {chunkCoord.Z})");
+                        snbtContent.AppendLine($"// Region: ({mcaFile.RegionCoordinates.X}, {mcaFile.RegionCoordinates.Z})");
+                        snbtContent.AppendLine($"// Compression: {chunkData.CompressionType}");
+                        snbtContent.AppendLine($"// Data size: {chunkData.DataLength} bytes");
+                        snbtContent.AppendLine($"// Extracted: {DateTime.UtcNow:yyyy-MM-ddTHH:mm:ssZ}");
+                        snbtContent.AppendLine();
+                        snbtContent.AppendLine(chunkData.NbtData.ToSnbt(SnbtOptions.DefaultExpanded));
+
+                        await File.WriteAllTextAsync(chunkFilePath, snbtContent.ToString(), Encoding.UTF8);
+                    }
+
+                    processedCount++;
+
+                    // Yield control occasionally to prevent UI freezing
+                    if (processedCount % 25 == 0)
+                        await Task.Yield();
+                }
+                catch (Exception ex)
+                {
+                    progress?.Report($"Error processing chunk ({chunkCoord.X}, {chunkCoord.Z}): {ex.Message}");
+                    // Continue with other chunks
+                }
+            }
+
+            progress?.Report($"Conversion complete! Created {processedCount} chunk files in {outputFolderPath}");
+        }
+        catch (Exception ex)
+        {
+            progress?.Report($"Failed to convert MCA to chunk files: {ex.Message}");
+            throw new InvalidOperationException($"Error converting {mcaFilePath} to chunk files: {ex.Message}", ex);
+        }
+    }
+
+    /// <summary>
+    ///     Convert folder of chunk SNBT files back to a single MCA file
+    /// </summary>
+    public async Task ConvertChunkFilesToMcaAsync(string chunkFolderPath, string outputMcaPath, IProgress<string>? progress = null)
+    {
+        try
+        {
+            progress?.Report($"Reading chunk files from: {chunkFolderPath}...");
+
+            if (!Directory.Exists(chunkFolderPath))
+                throw new DirectoryNotFoundException($"Chunk folder does not exist: {chunkFolderPath}");
+
+            // Find all chunk SNBT files
+            string[] chunkFiles = Directory.GetFiles(chunkFolderPath, "chunk_*.snbt");
+
+            if (chunkFiles.Length == 0)
+                throw new InvalidOperationException($"No chunk files found in {chunkFolderPath}");
+
+            progress?.Report($"Found {chunkFiles.Length} chunk files, processing...");
+
+            var chunks = new Dictionary<Point2I, NbtCompound>();
+            Point2I? regionCoords = null;
+
+            // Read region info if available
+            string regionInfoPath = Path.Combine(chunkFolderPath, "region_info.snbt");
+            if (File.Exists(regionInfoPath))
+            {
+                try
+                {
+                    string regionInfoSnbt = await File.ReadAllTextAsync(regionInfoPath, Encoding.UTF8);
+                    var regionInfo = SnbtParser.Parse(regionInfoSnbt, false) as NbtCompound;
+                    if (regionInfo != null)
+                    {
+                        int regionX = regionInfo.Get<NbtInt>("RegionX")?.Value ?? 0;
+                        int regionZ = regionInfo.Get<NbtInt>("RegionZ")?.Value ?? 0;
+                        regionCoords = new Point2I(regionX, regionZ);
+                        progress?.Report($"Found region info: ({regionX}, {regionZ})");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    progress?.Report($"Warning: Could not read region info: {ex.Message}");
+                }
+            }
+
+            // Process each chunk file
+            int processedCount = 0;
+            foreach (string chunkFile in chunkFiles)
+            {
+                try
+                {
+                    if (processedCount % 10 == 0 || processedCount == chunkFiles.Length - 1)
+                        progress?.Report($"Processing file {processedCount + 1}/{chunkFiles.Length}: {Path.GetFileName(chunkFile)}");
+
+                    // Extract chunk coordinates from filename: chunk_X_Z.snbt
+                    string fileName = Path.GetFileNameWithoutExtension(chunkFile);
+                    if (!fileName.StartsWith("chunk_"))
+                        continue;
+
+                    string[] parts = fileName.Split('_');
+                    if (parts.Length != 3 || !int.TryParse(parts[1], out int chunkX) || !int.TryParse(parts[2], out int chunkZ))
+                    {
+                        progress?.Report($"Warning: Invalid chunk filename format: {fileName}");
+                        continue;
+                    }
+
+                    var chunkCoord = new Point2I(chunkX, chunkZ);
+
+                    // Read and parse chunk SNBT
+                    string chunkSnbt = await File.ReadAllTextAsync(chunkFile, Encoding.UTF8);
+
+                    // Remove header comments and extract SNBT data
+                    var lines = chunkSnbt.Split('\n');
+                    var snbtLines = new List<string>();
+                    bool foundSnbtStart = false;
+
+                    foreach (string line in lines)
+                    {
+                        string trimmedLine = line.Trim();
+                        if (!foundSnbtStart && (trimmedLine.StartsWith("//") || string.IsNullOrEmpty(trimmedLine)))
+                            continue;
+
+                        foundSnbtStart = true;
+                        snbtLines.Add(line);
+                    }
+
+                    string cleanSnbt = string.Join('\n', snbtLines);
+                    var chunkNbt = SnbtParser.Parse(cleanSnbt, false) as NbtCompound;
+
+                    if (chunkNbt != null)
+                    {
+                        // Ensure root tag has a name
+                        if (string.IsNullOrEmpty(chunkNbt.Name))
+                            chunkNbt.Name = "";
+
+                        // Fix empty lists
+                        FixEmptyLists(chunkNbt);
+
+                        chunks[chunkCoord] = chunkNbt;
+                    }
+
+                    processedCount++;
+
+                    // Yield control occasionally
+                    if (processedCount % 25 == 0)
+                        await Task.Yield();
+                }
+                catch (Exception ex)
+                {
+                    progress?.Report($"Error processing chunk file {Path.GetFileName(chunkFile)}: {ex.Message}");
+                    // Continue with other files
+                }
+            }
+
+            if (chunks.Count == 0)
+                throw new InvalidOperationException("No valid chunk data found");
+
+            progress?.Report($"Successfully parsed {chunks.Count} chunks, creating MCA file...");
+
+            // Determine region coordinates if not found in region info
+            if (regionCoords == null)
+            {
+                Point2I firstChunk = chunks.First().Key;
+                int regionX = (int)Math.Floor(firstChunk.X / 32.0);
+                int regionZ = (int)Math.Floor(firstChunk.Z / 32.0);
+                regionCoords = new Point2I(regionX, regionZ);
+                progress?.Report($"Calculated region coordinates from chunks: ({regionX}, {regionZ})");
+            }
+
+            // Verify all chunks belong to the same region
+            foreach (var chunk in chunks)
+            {
+                int chunkRegionX = (int)Math.Floor(chunk.Key.X / 32.0);
+                int chunkRegionZ = (int)Math.Floor(chunk.Key.Z / 32.0);
+
+                if (chunkRegionX != regionCoords.Value.X || chunkRegionZ != regionCoords.Value.Z)
+                    throw new InvalidOperationException(
+                        $"Chunk ({chunk.Key.X}, {chunk.Key.Z}) belongs to region ({chunkRegionX}, {chunkRegionZ}), not ({regionCoords.Value.X}, {regionCoords.Value.Z})");
+            }
+
+            // Create MCA file
+            using var mcaWriter = new McaRegionWriter(outputMcaPath, regionCoords.Value);
+
+            // Add all chunks to the writer
+            int chunkCount = 0;
+            foreach (var chunk in chunks)
+            {
+                chunkCount++;
+                if (chunkCount % 10 == 0 || chunkCount == chunks.Count)
+                    progress?.Report($"Adding chunk {chunkCount}/{chunks.Count} to MCA file");
+
+                mcaWriter.AddChunk(
+                    chunk.Key,
+                    chunk.Value,
+                    CompressionType.Zlib, // Default to Zlib compression
+                    (uint)DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+                );
+            }
+
+            // Write the MCA file
+            progress?.Report("Writing MCA file...");
+            mcaWriter.WriteAsync();
+
+            progress?.Report($"Successfully created MCA file: {Path.GetFileName(outputMcaPath)} with {chunks.Count} chunks");
+        }
+        catch (Exception ex)
+        {
+            progress?.Report($"Failed to convert chunk files to MCA: {ex.Message}");
+            throw new InvalidOperationException($"Error converting chunk files to {outputMcaPath}: {ex.Message}", ex);
+        }
+    }
 }

--- a/Utils/Mca/McaRegionWriter.cs
+++ b/Utils/Mca/McaRegionWriter.cs
@@ -91,9 +91,9 @@ public class McaRegionWriter : IDisposable
     }
 
     /// <summary>
-    ///     Write the region file to disk
+    ///     Write the region file to disk synchronously
     /// </summary>
-    public void WriteAsync()
+    public void Write()
     {
         // Ensure output directory exists
         string? directory = Path.GetDirectoryName(_filePath);
@@ -104,11 +104,8 @@ public class McaRegionWriter : IDisposable
         try
         {
             using (var fileStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
-            using (var writer = new BinaryWriter(fileStream))
             {
-                WriteRegionFileAsync(writer);
-
-                writer.Flush();
+                WriteRegionFileSync(fileStream);
                 fileStream.Flush();
             }
 
@@ -128,25 +125,59 @@ public class McaRegionWriter : IDisposable
     }
 
     /// <summary>
-    ///     Write the complete region file structure
+    ///     Write the region file to disk asynchronously
     /// </summary>
-    private void WriteRegionFileAsync(BinaryWriter writer)
+    public async Task WriteAsync()
+    {
+        // Ensure output directory exists
+        string? directory = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory)) Directory.CreateDirectory(directory);
+
+        // Write to a temporary file first, then move to final location for atomic operation
+        string tempPath = _filePath + ".tmp";
+        try
+        {
+            await using (var fileStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096, useAsync: true))
+            {
+                await WriteRegionFileAsync(fileStream);
+                await fileStream.FlushAsync();
+            }
+
+            // Atomic move to final location
+            if (File.Exists(_filePath)) File.Delete(_filePath);
+            File.Move(tempPath, _filePath);
+        }
+        catch
+        {
+            // Clean up temp file on any error
+            if (File.Exists(tempPath))
+                try { File.Delete(tempPath); }
+                catch { }
+
+            throw;
+        }
+    }
+
+    /// <summary>
+    ///     Write the complete region file structure synchronously
+    /// </summary>
+    private void WriteRegionFileSync(Stream fileStream)
     {
         // Step 1: Serialize all chunks and calculate their positions
         var chunkSectors = new Dictionary<int, ChunkSectorInfo>();
         var chunkDataBuffer = new MemoryStream();
 
-        SerializeChunks(chunkDataBuffer, chunkSectors);
+        SerializeChunksSync(chunkDataBuffer, chunkSectors);
 
         // Step 2: Write chunk location table (4KB)
-        WriteChunkLocationTable(writer, chunkSectors);
+        WriteChunkLocationTableSync(fileStream, chunkSectors);
 
         // Step 3: Write timestamp table (4KB)
-        WriteTimestampTable(writer, chunkSectors);
+        WriteTimestampTableSync(fileStream, chunkSectors);
 
         // Step 4: Write chunk data
         byte[] chunkDataBytes = chunkDataBuffer.ToArray();
-        writer.Write(chunkDataBytes);
+        fileStream.Write(chunkDataBytes, 0, chunkDataBytes.Length);
 
         // Step 5: Pad to 4KB boundary if needed
         int totalSize = 8192 + chunkDataBytes.Length; // 8KB headers + chunk data
@@ -154,14 +185,47 @@ public class McaRegionWriter : IDisposable
         if (remainder != 0)
         {
             int padding = 4096 - remainder;
-            writer.Write(new byte[padding]);
+            byte[] paddingBytes = new byte[padding];
+            fileStream.Write(paddingBytes, 0, paddingBytes.Length);
         }
     }
 
     /// <summary>
-    ///     Serialize all chunks and calculate their sector positions
+    ///     Write the complete region file structure asynchronously
     /// </summary>
-    private void SerializeChunks(Stream chunkDataStream, Dictionary<int, ChunkSectorInfo> chunkSectors)
+    private async Task WriteRegionFileAsync(Stream fileStream)
+    {
+        // Step 1: Serialize all chunks and calculate their positions
+        var chunkSectors = new Dictionary<int, ChunkSectorInfo>();
+        var chunkDataBuffer = new MemoryStream();
+
+        await SerializeChunksAsync(chunkDataBuffer, chunkSectors);
+
+        // Step 2: Write chunk location table (4KB)
+        await WriteChunkLocationTableAsync(fileStream, chunkSectors);
+
+        // Step 3: Write timestamp table (4KB)
+        await WriteTimestampTableAsync(fileStream, chunkSectors);
+
+        // Step 4: Write chunk data
+        byte[] chunkDataBytes = chunkDataBuffer.ToArray();
+        await fileStream.WriteAsync(chunkDataBytes);
+
+        // Step 5: Pad to 4KB boundary if needed
+        int totalSize = 8192 + chunkDataBytes.Length; // 8KB headers + chunk data
+        int remainder = totalSize % 4096;
+        if (remainder != 0)
+        {
+            int padding = 4096 - remainder;
+            byte[] paddingBytes = new byte[padding];
+            await fileStream.WriteAsync(paddingBytes);
+        }
+    }
+
+    /// <summary>
+    ///     Serialize all chunks and calculate their sector positions synchronously
+    /// </summary>
+    private void SerializeChunksSync(Stream chunkDataStream, Dictionary<int, ChunkSectorInfo> chunkSectors)
     {
         using var writer = new BinaryWriter(chunkDataStream, Encoding.UTF8, true);
 
@@ -177,8 +241,7 @@ public class McaRegionWriter : IDisposable
             int chunkIndex = localCoords.ToChunkIndex();
 
             // Ensure NBT data is not null
-            if (chunkData.NbtData == null)
-                throw new InvalidOperationException($"Chunk {chunkCoordinates} has null NBT data");
+            ArgumentNullException.ThrowIfNull(chunkData.NbtData);
 
             // Serialize NBT data
             byte[] nbtData;
@@ -243,9 +306,96 @@ public class McaRegionWriter : IDisposable
     }
 
     /// <summary>
-    ///     Write the chunk location table (first 4KB of region file)
+    ///     Serialize all chunks and calculate their sector positions asynchronously
     /// </summary>
-    private void WriteChunkLocationTable(BinaryWriter writer, Dictionary<int, ChunkSectorInfo> chunkSectors)
+    private async Task SerializeChunksAsync(Stream chunkDataStream, Dictionary<int, ChunkSectorInfo> chunkSectors)
+    {
+        using var writer = new BinaryWriter(chunkDataStream, Encoding.UTF8, true);
+
+        int currentSector = 2; // Start after 8KB headers (2 sectors of 4KB each)
+
+        foreach (KeyValuePair<Point2I, ChunkData> kvp in _chunks)
+        {
+            Point2I chunkCoordinates = kvp.Key;
+            ChunkData chunkData = kvp.Value;
+
+            // Get local coordinates and chunk index
+            Point2I localCoords = chunkCoordinates.GetLocalCoordinates();
+            int chunkIndex = localCoords.ToChunkIndex();
+
+            // Ensure NBT data is not null
+            ArgumentNullException.ThrowIfNull(chunkData.NbtData);
+
+            // Serialize NBT data
+            byte[] nbtData;
+            using (var nbtStream = new MemoryStream())
+            {
+                var nbtFile = new NbtFile(chunkData.NbtData);
+                nbtFile.SaveToStream(nbtStream, NbtCompression.None);
+                nbtData = nbtStream.ToArray();
+            }
+
+            // Compress data
+            byte[] compressedData = CompressionHelper.Compress(nbtData, chunkData.CompressionType);
+
+            // Calculate total length (1 byte for compression type + compressed data)
+            int totalLength = 1 + compressedData.Length;
+            bool isOversized = totalLength > 1044476; // ~1MB limit for in-file storage
+
+            if (isOversized)
+                // TODO: Implement external .mcc file writing for oversized chunks
+                // For now, we'll compress more aggressively or throw an error
+                throw new InvalidOperationException(
+                    $"Chunk {chunkCoordinates} is too large ({totalLength} bytes). " +
+                    "Oversized chunk support (.mcc files) not yet implemented.");
+
+            // Write chunk data
+            long chunkStartPosition = writer.BaseStream.Position;
+
+            // Write length (4 bytes, big endian)
+            byte[] lengthBytes = BitConverter.GetBytes((uint)totalLength);
+            if (BitConverter.IsLittleEndian)
+                Array.Reverse(lengthBytes);
+            writer.Write(lengthBytes);
+
+            // Write compression type
+            writer.Write((byte)chunkData.CompressionType);
+
+            // Write compressed data
+            writer.Write(compressedData);
+
+            // Calculate sector count (round up to 4KB sectors)
+            int chunkSizeWithHeader = 4 + totalLength; // 4 bytes for length header
+            int sectorCount = (chunkSizeWithHeader + 4095) / 4096; // Round up division
+
+            // Pad to sector boundary
+            long currentPosition = writer.BaseStream.Position;
+            long sectorEndPosition = (currentSector + sectorCount) * 4096L;
+            long paddingNeeded = sectorEndPosition - (8192 + currentPosition);
+
+            if (paddingNeeded > 0) writer.Write(new byte[paddingNeeded]);
+
+            // Store sector information
+            chunkSectors[chunkIndex] = new ChunkSectorInfo
+            {
+                SectorOffset = (uint)currentSector,
+                SectorCount = (uint)sectorCount,
+                Timestamp = chunkData.Timestamp,
+                ChunkCoordinates = chunkCoordinates
+            };
+
+            currentSector += sectorCount;
+
+            // Yield control occasionally to prevent blocking
+            if (chunkIndex % 10 == 0)
+                await Task.Yield();
+        }
+    }
+
+    /// <summary>
+    ///     Write the chunk location table (first 4KB of region file) synchronously
+    /// </summary>
+    private void WriteChunkLocationTableSync(Stream stream, Dictionary<int, ChunkSectorInfo> chunkSectors)
     {
         byte[] locationTable = new byte[4096];
 
@@ -265,13 +415,39 @@ public class McaRegionWriter : IDisposable
             Array.Copy(locationBytes, 0, locationTable, i * 4, 4);
         }
 
-        writer.Write(locationTable);
+        stream.Write(locationTable, 0, locationTable.Length);
     }
 
     /// <summary>
-    ///     Write the timestamp table (second 4KB of region file)
+    ///     Write the chunk location table (first 4KB of region file) asynchronously
     /// </summary>
-    private void WriteTimestampTable(BinaryWriter writer, Dictionary<int, ChunkSectorInfo> chunkSectors)
+    private async Task WriteChunkLocationTableAsync(Stream stream, Dictionary<int, ChunkSectorInfo> chunkSectors)
+    {
+        byte[] locationTable = new byte[4096];
+
+        for (int i = 0; i < 1024; i++)
+        {
+            uint locationData = 0;
+
+            if (chunkSectors.TryGetValue(i, out ChunkSectorInfo? sectorInfo))
+                // Pack sector offset (24 bits) and sector count (8 bits)
+                locationData = (sectorInfo.SectorOffset << 8) | (sectorInfo.SectorCount & 0xFF);
+
+            // Write as big endian
+            byte[] locationBytes = BitConverter.GetBytes(locationData);
+            if (BitConverter.IsLittleEndian)
+                Array.Reverse(locationBytes);
+
+            Array.Copy(locationBytes, 0, locationTable, i * 4, 4);
+        }
+
+        await stream.WriteAsync(locationTable);
+    }
+
+    /// <summary>
+    ///     Write the timestamp table (second 4KB of region file) synchronously
+    /// </summary>
+    private void WriteTimestampTableSync(Stream stream, Dictionary<int, ChunkSectorInfo> chunkSectors)
     {
         byte[] timestampTable = new byte[4096];
 
@@ -289,7 +465,31 @@ public class McaRegionWriter : IDisposable
             Array.Copy(timestampBytes, 0, timestampTable, i * 4, 4);
         }
 
-        writer.Write(timestampTable);
+        stream.Write(timestampTable, 0, timestampTable.Length);
+    }
+
+    /// <summary>
+    ///     Write the timestamp table (second 4KB of region file) asynchronously
+    /// </summary>
+    private async Task WriteTimestampTableAsync(Stream stream, Dictionary<int, ChunkSectorInfo> chunkSectors)
+    {
+        byte[] timestampTable = new byte[4096];
+
+        for (int i = 0; i < 1024; i++)
+        {
+            uint timestamp = 0;
+
+            if (chunkSectors.TryGetValue(i, out ChunkSectorInfo? sectorInfo)) timestamp = sectorInfo.Timestamp;
+
+            // Write as big endian
+            byte[] timestampBytes = BitConverter.GetBytes(timestamp);
+            if (BitConverter.IsLittleEndian)
+                Array.Reverse(timestampBytes);
+
+            Array.Copy(timestampBytes, 0, timestampTable, i * 4, 4);
+        }
+
+        await stream.WriteAsync(timestampTable);
     }
 
     /// <summary>

--- a/Views/SaveTranslatorPage.xaml
+++ b/Views/SaveTranslatorPage.xaml
@@ -74,7 +74,7 @@
                     Margin="0,8,0,0"
                     Padding="12">
                     <StackPanel Spacing="8">
-                        <TextBlock FontWeight="SemiBold" Text="MCA Processing Mode" />
+                        <TextBlock FontWeight="SemiBold" Text="{ext:Localize Key=SaveTranslator_McaProcessingMode}" />
                         <RadioButton
                             Content="Standard MCA → SNBT (Single file per region)"
                             GroupName="McaProcessingMode"

--- a/Views/SaveTranslatorPage.xaml
+++ b/Views/SaveTranslatorPage.xaml
@@ -64,6 +64,33 @@
                     Content="{ext:Localize Key=SaveTranslator_WorldData}"
                     IsChecked="True"
                     x:Name="LevelDataCheckBox" />
+
+                <!--  MCA Processing Mode  -->
+                <Border
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="4"
+                    Margin="0,8,0,0"
+                    Padding="12">
+                    <StackPanel Spacing="8">
+                        <TextBlock FontWeight="SemiBold" Text="MCA Processing Mode" />
+                        <RadioButton
+                            Content="Standard MCA → SNBT (Single file per region)"
+                            GroupName="McaProcessingMode"
+                            IsChecked="True"
+                            x:Name="StandardMcaRadioButton" />
+                        <RadioButton
+                            Content="Chunk-based → Individual SNBT files (One file per chunk)"
+                            GroupName="McaProcessingMode"
+                            x:Name="ChunkBasedMcaRadioButton" />
+                        <TextBlock
+                            FontSize="12"
+                            Opacity="0.8"
+                            Text="Standard MCA converts each file to an SNBT file, chunk-based mode creates separate SNBT files for each chunk."
+                            TextWrapping="Wrap" />
+                    </StackPanel>
+                </Border>
             </StackPanel>
 
             <!--  Output settings  -->

--- a/Views/SaveTranslatorPage.xaml.cs
+++ b/Views/SaveTranslatorPage.xaml.cs
@@ -459,7 +459,7 @@ public sealed partial class SaveTranslatorPage : Page
                     // For MCA files, check if multi-chunk was detected
                     if (extension == ".mca" || extension == ".mcc")
                     {
-                        string snbtContent = File.ReadAllText(tempSnbtPath);
+                        string snbtContent = await File.ReadAllTextAsync(tempSnbtPath, cancellationToken);
                         if (snbtContent.Contains("# Chunk"))
                         {
                             // Optimized: Count occurrences without Split to avoid massive memory allocations
@@ -613,12 +613,30 @@ public sealed partial class SaveTranslatorPage : Page
                     LogMessage($"    {message}");
             });
 
-            // Use the enhanced async NbtService with minimal progress reporting
-            await _nbtService.ConvertToSnbtAsync(inputPath, outputPath, progress);
+            // Check if this is an MCA file and chunk-based mode is enabled
+            bool isChunkBasedMode = ChunkBasedMcaRadioButton?.IsChecked == true;
 
-            // Verify output was created
-            if (!File.Exists(outputPath))
-                throw new InvalidOperationException($"SNBT output file was not created: {outputPath}");
+            if ((extension == ".mca" || extension == ".mcc") && isChunkBasedMode)
+            {
+                // Use chunk-based processing
+                string chunkFolderPath = Path.ChangeExtension(outputPath, ".chunks");
+                await _nbtService.ConvertMcaToChunkFilesAsync(inputPath, chunkFolderPath, progress);
+
+                // Create a marker file to indicate this is chunk-based output
+                string markerPath = outputPath + ".chunk_mode";
+                await File.WriteAllTextAsync(markerPath, chunkFolderPath, Encoding.UTF8, cancellationToken);
+
+                LogMessage($"    ✓ Created {Directory.GetFiles(chunkFolderPath, "chunk_*.snbt").Length} chunk files");
+            }
+            else
+            {
+                // Use standard single-file conversion
+                await _nbtService.ConvertToSnbtAsync(inputPath, outputPath, progress);
+
+                // Verify output was created
+                if (!File.Exists(outputPath))
+                    throw new InvalidOperationException($"SNBT output file was not created: {outputPath}");
+            }
         }
         catch (Exception ex)
         {
@@ -634,12 +652,6 @@ public sealed partial class SaveTranslatorPage : Page
     {
         try
         {
-            // Add file validation before conversion
-            if (!File.Exists(inputPath)) throw new FileNotFoundException($"SNBT input file not found: {inputPath}");
-
-            var fileInfo = new FileInfo(inputPath);
-            if (fileInfo.Length == 0) throw new InvalidDataException($"SNBT input file is empty: {inputPath}");
-
             // Create minimal progress reporter to reduce UI overhead
             var progress = new Progress<string>(message =>
             {
@@ -648,12 +660,44 @@ public sealed partial class SaveTranslatorPage : Page
                     LogMessage($"    {message}");
             });
 
-            // Use the enhanced async NbtService with minimal progress reporting
-            await _nbtService.ConvertFromSnbtAsync(inputPath, outputPath, progress);
+            // Check if this was processed in chunk-based mode
+            string markerPath = inputPath + ".chunk_mode";
+            if (File.Exists(markerPath) && (extension == ".mca" || extension == ".mcc"))
+            {
+                // Read chunk folder path from marker file
+                string chunkFolderPath = await File.ReadAllTextAsync(markerPath, Encoding.UTF8, cancellationToken);
+
+                if (Directory.Exists(chunkFolderPath))
+                {
+                    // Convert chunk files back to MCA
+                    await _nbtService.ConvertChunkFilesToMcaAsync(chunkFolderPath, outputPath, progress);
+
+                    // Clean up marker file
+                    File.Delete(markerPath);
+
+                    LogMessage($"    ✓ Reconstructed MCA from {Directory.GetFiles(chunkFolderPath, "chunk_*.snbt").Length} chunk files");
+                }
+                else
+                {
+                    throw new DirectoryNotFoundException($"Chunk folder not found: {chunkFolderPath}");
+                }
+            }
+            else
+            {
+                // Standard single-file conversion
+                // Add file validation before conversion
+                if (!File.Exists(inputPath)) throw new FileNotFoundException($"SNBT input file not found: {inputPath}");
+
+                var fileInfo = new FileInfo(inputPath);
+                if (fileInfo.Length == 0) throw new InvalidDataException($"SNBT input file is empty: {inputPath}");
+
+                // Use the enhanced async NbtService with minimal progress reporting
+                await _nbtService.ConvertFromSnbtAsync(inputPath, outputPath, progress);
+            }
 
             // Verify output was created
             if (!File.Exists(outputPath))
-                throw new InvalidOperationException($"NBT output file was not created: {outputPath}");
+                throw new InvalidOperationException($"Output file was not created: {outputPath}");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Previously, each .mca file was translated to a .snbt file in a one-to-one mapping strategy. It is not ideal for Git as it does not work well with large files.

This PR proposes an alternative approach by splitting each chunk of information in the .mca file into a separate files, stored in the corresponding folder under GitMC/region. Tests are available in `Save translator` util in Settings -> Debug tools.